### PR TITLE
add K8s deployment task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM hashicorp/http-echo:latest
+
+EXPOSE 5678
+
+CMD ["-text=Hello World!"]

--- a/k8s-deployment/deployment.yaml
+++ b/k8s-deployment/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cm-interview
+  labels:
+    app: interview-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: interview-app
+  namespace: cm-interview
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: interview-app
+  template:
+    metadata:
+      labels:
+        app: interview-app
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: interview-app
+          image: ghcr.io/yanirain/cm-interview:v1.0.0
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          ports:
+            - containerPort: 5678
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5678
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5678
+            initialDelaySeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: interview-app
+  namespace: cm-interview
+  labels:
+    app: interview-app
+spec:
+  selector:
+    app: interview-app
+  ports:
+    - port: 8080
+      targetPort: 5678


### PR DESCRIPTION
Adding the basic requirements for the 'k8s deployment' task
- **Dockerfile** - using "hashicorp/http-echo" to have a basic web server.
- **.github/workflows/release.yml** - basic GitHub Actions flow to build and publish the Docker image, triggered on version tags.
- **deployment.yml** - a basic Kubernetes deployment file to deploy the Docker in a Kubernetes cluster.